### PR TITLE
separate install and startup, and stop using nodemon

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,1 @@
+npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "la1tv-roses-graphics",
 	"version": "1.0.0",
+	"scripts": {
+		"start":"nodemon server.js"
+	},
 	"dependencies": {
 		"express": "^4.15.2",
 		"socket.io": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
 	"dependencies": {
 		"express": "*",
 		"socket.io": "*",
-		"underscore": "*",
-		"nodemon": "*"
+		"underscore": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
 	"name": "la1tv-roses-graphics",
 	"version": "1.0.0",
 	"dependencies": {
-		"express": "*",
-		"socket.io": "*",
-		"underscore": "*"
+		"express": "^4.15.2",
+		"socket.io": "^1.7.3",
+		"underscore": "^1.8.3",
+		"nodemon": "^1.11.0"
 	}
 }

--- a/startup.bat
+++ b/startup.bat
@@ -1,1 +1,1 @@
-node server.js
+npm start

--- a/startup.bat
+++ b/startup.bat
@@ -1,2 +1,1 @@
-npm install
-nodemon server.js
+node server.js


### PR DESCRIPTION
unless nodemon is installed globally (`npm install -g nodemon`), it can't
be called from the command line like that on neither windows nor linux