### PR TITLE
Fix stopwatch bug when setValue() called with invalid value

### DIFF
--- a/models/stopwatch.js
+++ b/models/stopwatch.js
@@ -75,6 +75,10 @@ Stopwatch.prototype.countDown = function() {
 Stopwatch.prototype.setValue = function(val) {
     var pattern = /^(?:(?:(?:(\d+):)?(\d+):)?(\d+)(?:\.(\d))?)$/;
     var match = pattern.exec(val);
+    if (!match) {
+        // ignore invalid value
+        return;
+    }
 
     this.time = (this.hour * parseInt(match[1])||0) + (this.minute * parseInt(match[2])||0) + (this.second * parseInt(match[3])||0) + (this.decisecond * parseInt(match[4])||0);
     this.emit('tick:stopwatch', this.formatTime(this.time));

--- a/models/stopwatch.js
+++ b/models/stopwatch.js
@@ -76,7 +76,7 @@ Stopwatch.prototype.setValue = function(val) {
     var pattern = /^(?:(?:(?:(\d+):)?(\d+):)?(\d+)(?:\.(\d))?)$/;
     var match = pattern.exec(val);
 
-    this.time = (this.hour * parseInt(match[1])|0) + (this.minute * parseInt(match[2])|0) + (this.second * parseInt(match[3])|0) + (this.decisecond * parseInt(match[4])|0);
+    this.time = (this.hour * parseInt(match[1])||0) + (this.minute * parseInt(match[2])||0) + (this.second * parseInt(match[3])||0) + (this.decisecond * parseInt(match[4])||0);
     this.emit('tick:stopwatch', this.formatTime(this.time));
 }
 


### PR DESCRIPTION
It was a bitwise or (which has no effect) instead of a logical one

Fixes #47 