### PR TITLE
Fix 1920px controller shrink

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -25,3 +25,16 @@ html, body {
 .ui.form .field {
     margin-bottom: 0px;
 }
+
+
+
+/**************************************************/
+/*              [Fix Semantic]                    */
+/**************************************************/
+
+@media only screen and (min-width: 1920px) {
+  .ui.page.grid {
+    padding-left: 0% !important;
+    padding-right: 0% !important;
+  }
+}


### PR DESCRIPTION
There's an annoying shrink down to around 1000px when the backend gets to 1920px. Here's my suggested fix but other people might not mind it. 

My argument is that when it shrinks down to 1000px you get buttons crashing into each other on the busier backends. 

I'm happy to go for like 2-5% padding if someone's really really anal. 